### PR TITLE
Guifixes for RequestContactDialog.ui

### DIFF
--- a/src/contactrequest.ui
+++ b/src/contactrequest.ui
@@ -10,6 +10,12 @@
     <height>427</height>
    </rect>
   </property>
+  <property name="sizePolicy">
+   <sizepolicy hsizetype="Expanding" vsizetype="Expanding">
+    <horstretch>0</horstretch>
+    <verstretch>0</verstretch>
+   </sizepolicy>
+  </property>
   <property name="maximumSize">
    <size>
     <width>780</width>
@@ -20,105 +26,9 @@
    <string>Send a contact request</string>
   </property>
   <layout class="QGridLayout" name="gridLayout">
-   <item row="0" column="2" colspan="2">
-    <widget class="QLabel" name="label_6">
-     <property name="text">
-      <string>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p align=&quot;right&quot;&gt;&lt;span style=&quot; font-weight:600; text-decoration: underline;&quot;&gt;Choose a avatar for your contact :&lt;/span&gt;&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
-     </property>
-    </widget>
-   </item>
-   <item row="1" column="0" colspan="2">
-    <widget class="QLabel" name="label_3">
-     <property name="text">
-      <string>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;&lt;span style=&quot; font-weight:600; text-decoration: underline;&quot;&gt;Please insert a Nickname for your contact :&lt;/span&gt;&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
-     </property>
-    </widget>
-   </item>
-   <item row="2" column="0" colspan="2">
-    <widget class="QLineEdit" name="labelRequest">
-     <property name="maxLength">
-      <number>25</number>
-     </property>
-    </widget>
-   </item>
-   <item row="3" column="0" colspan="2">
-    <widget class="QLabel" name="label">
-     <property name="text">
-      <string>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;&lt;span style=&quot; font-weight:600; text-decoration: underline;&quot;&gt;Please insert the Address of your contact :&lt;/span&gt;&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
-     </property>
-    </widget>
-   </item>
-   <item row="4" column="0" colspan="4">
-    <widget class="QLineEdit" name="zaddr">
-     <property name="minimumSize">
-      <size>
-       <width>650</width>
-       <height>25</height>
-      </size>
-     </property>
-     <property name="maximumSize">
-      <size>
-       <width>650</width>
-       <height>25</height>
-      </size>
-     </property>
-    </widget>
-   </item>
-   <item row="5" column="0" colspan="2">
-    <widget class="QLabel" name="label_4">
-     <property name="text">
-      <string>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;&lt;span style=&quot; font-weight:600; text-decoration: underline;&quot;&gt;Your HushChat Address :&lt;/span&gt;&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
-     </property>
-    </widget>
-   </item>
-   <item row="6" column="0" colspan="4">
-    <widget class="QLabel" name="myzaddr">
-     <property name="minimumSize">
-      <size>
-       <width>650</width>
-       <height>25</height>
-      </size>
-     </property>
-     <property name="maximumSize">
-      <size>
-       <width>650</width>
-       <height>25</height>
-      </size>
-     </property>
-     <property name="text">
-      <string>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;&lt;span style=&quot; color:#d3d7cf;&quot;&gt;Generate your HushChat Address - please wait a second - &lt;/span&gt;&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
-     </property>
-    </widget>
-   </item>
-   <item row="7" column="0" rowspan="2">
-    <spacer name="verticalSpacer">
-     <property name="orientation">
-      <enum>Qt::Vertical</enum>
-     </property>
-     <property name="sizeHint" stdset="0">
-      <size>
-       <width>20</width>
-       <height>148</height>
-      </size>
-     </property>
-    </spacer>
-   </item>
-   <item row="7" column="1">
-    <widget class="QLabel" name="label_2">
-     <property name="text">
-      <string>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p align=&quot;center&quot;&gt;&lt;span style=&quot; font-weight:600; text-decoration: underline;&quot;&gt;Insert a memo for your request&lt;/span&gt;&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
-     </property>
-    </widget>
-   </item>
-   <item row="8" column="1" colspan="3">
+   <item row="9" column="0">
     <widget class="QLineEdit" name="memorequest">
      <property name="minimumSize">
-      <size>
-       <width>500</width>
-       <height>71</height>
-      </size>
-     </property>
-     <property name="maximumSize">
       <size>
        <width>500</width>
        <height>71</height>
@@ -143,15 +53,69 @@
       <bool>false</bool>
      </property>
      <property name="placeholderText">
-      <string>Add some memo to your request</string>
+      <string>Add a memo to your request</string>
      </property>
      <property name="clearButtonEnabled">
       <bool>true</bool>
      </property>
     </widget>
    </item>
-   <item row="9" column="0">
+   <item row="5" column="0" colspan="5">
+    <widget class="QLineEdit" name="zaddr">
+     <property name="minimumSize">
+      <size>
+       <width>650</width>
+       <height>25</height>
+      </size>
+     </property>
+     <property name="maximumSize">
+      <size>
+       <width>650</width>
+       <height>25</height>
+      </size>
+     </property>
+    </widget>
+   </item>
+   <item row="11" column="4" colspan="2">
+    <widget class="QPushButton" name="sendRequestButton">
+     <property name="text">
+      <string>Add Contact and Send Request</string>
+     </property>
+     <property name="autoDefault">
+      <bool>false</bool>
+     </property>
+     <property name="flat">
+      <bool>false</bool>
+     </property>
+    </widget>
+   </item>
+   <item row="7" column="0" colspan="5" alignment="Qt::AlignLeft">
+    <widget class="QLabel" name="myzaddr">
+     <property name="minimumSize">
+      <size>
+       <width>650</width>
+       <height>25</height>
+      </size>
+     </property>
+     <property name="maximumSize">
+      <size>
+       <width>650</width>
+       <height>25</height>
+      </size>
+     </property>
+     <property name="text">
+      <string>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;&lt;span style=&quot; color:#d3d7cf;&quot;&gt;Generate your HushChat Address - please wait a second - &lt;/span&gt;&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
+     </property>
+    </widget>
+   </item>
+   <item row="11" column="3" alignment="Qt::AlignRight">
     <widget class="QPushButton" name="cancel">
+     <property name="sizePolicy">
+      <sizepolicy hsizetype="Fixed" vsizetype="Fixed">
+       <horstretch>0</horstretch>
+       <verstretch>0</verstretch>
+      </sizepolicy>
+     </property>
      <property name="baseSize">
       <size>
        <width>100</width>
@@ -169,172 +133,325 @@
      </property>
     </widget>
    </item>
-   <item row="9" column="1">
-    <spacer name="horizontalSpacer">
-     <property name="orientation">
-      <enum>Qt::Horizontal</enum>
-     </property>
-     <property name="sizeHint" stdset="0">
-      <size>
-       <width>278</width>
-       <height>20</height>
-      </size>
-     </property>
-    </spacer>
-   </item>
-   <item row="9" column="3" colspan="2">
-    <widget class="QPushButton" name="sendRequestButton">
+   <item row="8" column="0" colspan="2">
+    <widget class="QLabel" name="label_2">
      <property name="text">
-      <string>Add Contact and send request</string>
-     </property>
-     <property name="autoDefault">
-      <bool>false</bool>
-     </property>
-     <property name="flat">
-      <bool>false</bool>
+      <string>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;&lt;span style=&quot; font-weight:600; text-decoration: underline;&quot;&gt;Insert a memo for your request:&lt;/span&gt;&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
      </property>
     </widget>
    </item>
-   <item row="2" column="2">
-    <widget class="QComboBox" name="comboBoxAvatar">
-     <item>
-      <property name="text">
-       <string>SDLogo</string>
-      </property>
-      <property name="icon">
-       <iconset>
-        <activeon>:/icons/res/SDLogo.png</activeon>
-       </iconset>
-      </property>
-     </item>
-     <item>
-      <property name="text">
-       <string>Duke</string>
-      </property>
-      <property name="icon">
-       <iconset>
-        <activeon>:/icons/res/Duke.png</activeon>
-       </iconset>
-      </property>
-     </item>
-     <item>
-      <property name="text">
-       <string>Denio</string>
-      </property>
-      <property name="icon">
-       <iconset>
-        <activeon>:/icons/res/Denio.png</activeon>
-       </iconset>
-      </property>
-     </item>
-     <item>
-      <property name="text">
-       <string>Berg</string>
-      </property>
-      <property name="icon">
-       <iconset>
-        <activeon>:/icons/res/Berg.png</activeon>
-       </iconset>
-      </property>
-     </item>
-     <item>
-      <property name="text">
-       <string>Stag</string>
-      </property>
-      <property name="icon">
-       <iconset>
-        <activeon>:/icons/res/Stag.png</activeon>
-       </iconset>
-      </property>
-     </item>
-     <item>
-      <property name="text">
-       <string>Sharpee</string>
-      </property>
-      <property name="icon">
-       <iconset>
-        <activeon>:/icons/res/Sharpee.png</activeon>
-       </iconset>
-      </property>
-     </item>
-     <item>
-      <property name="text">
-       <string>Elsa</string>
-      </property>
-      <property name="icon">
-       <iconset>
-        <normalon>:/icons/res/Elsa.png</normalon>
-       </iconset>
-      </property>
-     </item>
-     <item>
-      <property name="text">
-       <string>Yoda</string>
-      </property>
-      <property name="icon">
-       <iconset>
-        <activeon>:/icons/res/Yoda.png</activeon>
-       </iconset>
-      </property>
-     </item>
-     <item>
-      <property name="text">
-       <string>Garfield</string>
-      </property>
-      <property name="icon">
-       <iconset>
-        <activeon>:/icons/res/Garfield.png</activeon>
-       </iconset>
-      </property>
-     </item>
-     <item>
-      <property name="text">
-       <string>Snoopy</string>
-      </property>
-      <property name="icon">
-       <iconset>
-        <activeon>:/icons/res/Snoopy.png</activeon>
-       </iconset>
-      </property>
-     </item>
-     <item>
-      <property name="text">
-       <string>Popey</string>
-      </property>
-      <property name="icon">
-       <iconset>
-        <activeon>:/icons/res/Popey.png</activeon>
-       </iconset>
-      </property>
-     </item>
-     <item>
-      <property name="text">
-       <string>Pinguin</string>
-      </property>
-      <property name="icon">
-       <iconset>
-        <activeon>:/icons/res/Pinguin.png</activeon>
-       </iconset>
-      </property>
-     </item>
-     <item>
-      <property name="text">
-       <string>Mickey</string>
-      </property>
-      <property name="icon">
-       <iconset>
-        <activeon>:/icons/res/Mickey.png</activeon>
-       </iconset>
-      </property>
-     </item>
-    </widget>
-   </item>
-   <item row="5" column="2">
-    <widget class="QPushButton" name="newZaddr">
+   <item row="4" column="0" colspan="3">
+    <widget class="QLabel" name="label">
      <property name="text">
-      <string>Create new Hushchat address</string>
+      <string>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;&lt;span style=&quot; font-weight:600; text-decoration: underline;&quot;&gt;Insert the address of your contact:&lt;/span&gt;&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
      </property>
     </widget>
+   </item>
+   <item row="6" column="0" colspan="6">
+    <layout class="QHBoxLayout" name="horizontalLayout">
+     <property name="spacing">
+      <number>12</number>
+     </property>
+     <property name="sizeConstraint">
+      <enum>QLayout::SetDefaultConstraint</enum>
+     </property>
+     <item>
+      <widget class="QLabel" name="label_4">
+       <property name="sizePolicy">
+        <sizepolicy hsizetype="Fixed" vsizetype="Preferred">
+         <horstretch>0</horstretch>
+         <verstretch>0</verstretch>
+        </sizepolicy>
+       </property>
+       <property name="text">
+        <string>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;&lt;span style=&quot; font-weight:600; text-decoration: underline;&quot;&gt;Your HushChat Address:&lt;/span&gt;&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
+       </property>
+      </widget>
+     </item>
+     <item>
+      <widget class="QPushButton" name="newZaddr">
+       <property name="sizePolicy">
+        <sizepolicy hsizetype="Minimum" vsizetype="Fixed">
+         <horstretch>0</horstretch>
+         <verstretch>0</verstretch>
+        </sizepolicy>
+       </property>
+       <property name="text">
+        <string>Create New Address</string>
+       </property>
+       <property name="autoDefault">
+        <bool>false</bool>
+       </property>
+      </widget>
+     </item>
+     <item>
+      <spacer name="horizontalSpacer">
+       <property name="orientation">
+        <enum>Qt::Horizontal</enum>
+       </property>
+       <property name="sizeHint" stdset="0">
+        <size>
+         <width>40</width>
+         <height>20</height>
+        </size>
+       </property>
+      </spacer>
+     </item>
+    </layout>
+   </item>
+   <item row="3" column="0" colspan="6">
+    <layout class="QHBoxLayout" name="horizontalLayout_2">
+     <item>
+      <widget class="QLineEdit" name="labelRequest">
+       <property name="sizePolicy">
+        <sizepolicy hsizetype="Fixed" vsizetype="Fixed">
+         <horstretch>0</horstretch>
+         <verstretch>0</verstretch>
+        </sizepolicy>
+       </property>
+       <property name="minimumSize">
+        <size>
+         <width>250</width>
+         <height>25</height>
+        </size>
+       </property>
+       <property name="maxLength">
+        <number>25</number>
+       </property>
+      </widget>
+     </item>
+     <item>
+      <spacer name="horizontalSpacer_3">
+       <property name="orientation">
+        <enum>Qt::Horizontal</enum>
+       </property>
+       <property name="sizeType">
+        <enum>QSizePolicy::Fixed</enum>
+       </property>
+       <property name="sizeHint" stdset="0">
+        <size>
+         <width>40</width>
+         <height>20</height>
+        </size>
+       </property>
+      </spacer>
+     </item>
+     <item>
+      <widget class="QComboBox" name="comboBoxAvatar">
+       <property name="minimumSize">
+        <size>
+         <width>0</width>
+         <height>25</height>
+        </size>
+       </property>
+       <item>
+        <property name="text">
+         <string>SDLogo</string>
+        </property>
+        <property name="icon">
+         <iconset>
+          <activeon>:/icons/res/SDLogo.png</activeon>
+         </iconset>
+        </property>
+       </item>
+       <item>
+        <property name="text">
+         <string>Duke</string>
+        </property>
+        <property name="icon">
+         <iconset>
+          <activeon>:/icons/res/Duke.png</activeon>
+         </iconset>
+        </property>
+       </item>
+       <item>
+        <property name="text">
+         <string>Denio</string>
+        </property>
+        <property name="icon">
+         <iconset>
+          <activeon>:/icons/res/Denio.png</activeon>
+         </iconset>
+        </property>
+       </item>
+       <item>
+        <property name="text">
+         <string>Berg</string>
+        </property>
+        <property name="icon">
+         <iconset>
+          <activeon>:/icons/res/Berg.png</activeon>
+         </iconset>
+        </property>
+       </item>
+       <item>
+        <property name="text">
+         <string>Stag</string>
+        </property>
+        <property name="icon">
+         <iconset>
+          <activeon>:/icons/res/Stag.png</activeon>
+         </iconset>
+        </property>
+       </item>
+       <item>
+        <property name="text">
+         <string>Sharpee</string>
+        </property>
+        <property name="icon">
+         <iconset>
+          <activeon>:/icons/res/Sharpee.png</activeon>
+         </iconset>
+        </property>
+       </item>
+       <item>
+        <property name="text">
+         <string>Elsa</string>
+        </property>
+        <property name="icon">
+         <iconset>
+          <normalon>:/icons/res/Elsa.png</normalon>
+         </iconset>
+        </property>
+       </item>
+       <item>
+        <property name="text">
+         <string>Yoda</string>
+        </property>
+        <property name="icon">
+         <iconset>
+          <activeon>:/icons/res/Yoda.png</activeon>
+         </iconset>
+        </property>
+       </item>
+       <item>
+        <property name="text">
+         <string>Garfield</string>
+        </property>
+        <property name="icon">
+         <iconset>
+          <activeon>:/icons/res/Garfield.png</activeon>
+         </iconset>
+        </property>
+       </item>
+       <item>
+        <property name="text">
+         <string>Snoopy</string>
+        </property>
+        <property name="icon">
+         <iconset>
+          <activeon>:/icons/res/Snoopy.png</activeon>
+         </iconset>
+        </property>
+       </item>
+       <item>
+        <property name="text">
+         <string>Popey</string>
+        </property>
+        <property name="icon">
+         <iconset>
+          <activeon>:/icons/res/Popey.png</activeon>
+         </iconset>
+        </property>
+       </item>
+       <item>
+        <property name="text">
+         <string>Pinguin</string>
+        </property>
+        <property name="icon">
+         <iconset>
+          <activeon>:/icons/res/Pinguin.png</activeon>
+         </iconset>
+        </property>
+       </item>
+       <item>
+        <property name="text">
+         <string>Mickey</string>
+        </property>
+        <property name="icon">
+         <iconset>
+          <activeon>:/icons/res/Mickey.png</activeon>
+         </iconset>
+        </property>
+       </item>
+      </widget>
+     </item>
+     <item>
+      <spacer name="horizontalSpacer_2">
+       <property name="orientation">
+        <enum>Qt::Horizontal</enum>
+       </property>
+       <property name="sizeType">
+        <enum>QSizePolicy::Expanding</enum>
+       </property>
+       <property name="sizeHint" stdset="0">
+        <size>
+         <width>40</width>
+         <height>20</height>
+        </size>
+       </property>
+      </spacer>
+     </item>
+    </layout>
+   </item>
+   <item row="0" column="0" colspan="6">
+    <layout class="QHBoxLayout" name="horizontalLayout_3">
+     <item alignment="Qt::AlignLeft">
+      <widget class="QLabel" name="label_3">
+       <property name="sizePolicy">
+        <sizepolicy hsizetype="Fixed" vsizetype="Preferred">
+         <horstretch>0</horstretch>
+         <verstretch>0</verstretch>
+        </sizepolicy>
+       </property>
+       <property name="text">
+        <string>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;&lt;span style=&quot; font-weight:600; text-decoration: underline;&quot;&gt;Insert a nickname for your contact:&lt;/span&gt;&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
+       </property>
+      </widget>
+     </item>
+     <item>
+      <spacer name="horizontalSpacer_4">
+       <property name="orientation">
+        <enum>Qt::Horizontal</enum>
+       </property>
+       <property name="sizeType">
+        <enum>QSizePolicy::Fixed</enum>
+       </property>
+       <property name="sizeHint" stdset="0">
+        <size>
+         <width>40</width>
+         <height>20</height>
+        </size>
+       </property>
+      </spacer>
+     </item>
+     <item>
+      <widget class="QLabel" name="label_6">
+       <property name="sizePolicy">
+        <sizepolicy hsizetype="Fixed" vsizetype="Preferred">
+         <horstretch>0</horstretch>
+         <verstretch>0</verstretch>
+        </sizepolicy>
+       </property>
+       <property name="text">
+        <string>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;&lt;span style=&quot; font-weight:600; text-decoration: underline;&quot;&gt;Choose an avatar for your contact:&lt;/span&gt;&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
+       </property>
+      </widget>
+     </item>
+     <item>
+      <spacer name="horizontalSpacer_5">
+       <property name="orientation">
+        <enum>Qt::Horizontal</enum>
+       </property>
+       <property name="sizeHint" stdset="0">
+        <size>
+         <width>40</width>
+         <height>20</height>
+        </size>
+       </property>
+      </spacer>
+     </item>
+    </layout>
    </item>
   </layout>
  </widget>

--- a/src/requestContactDialog.ui
+++ b/src/requestContactDialog.ui
@@ -10,9 +10,15 @@
     <height>495</height>
    </rect>
   </property>
+  <property name="sizePolicy">
+   <sizepolicy hsizetype="Minimum" vsizetype="Preferred">
+    <horstretch>0</horstretch>
+    <verstretch>0</verstretch>
+   </sizepolicy>
+  </property>
   <property name="minimumSize">
    <size>
-    <width>812</width>
+    <width>850</width>
     <height>495</height>
    </size>
   </property>
@@ -20,39 +26,10 @@
    <string>Incoming contact request</string>
   </property>
   <layout class="QGridLayout" name="gridLayout">
-   <item row="0" column="0">
-    <widget class="QLabel" name="label">
-     <property name="text">
-      <string>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p align=&quot;center&quot;&gt;&lt;span style=&quot; font-weight:600; text-decoration: underline;&quot;&gt;Open requests&lt;/span&gt;&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
-     </property>
-    </widget>
-   </item>
-   <item row="0" column="2" colspan="3">
+   <item row="0" column="1">
     <widget class="QLabel" name="label_3">
      <property name="text">
-      <string>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p align=&quot;center&quot;&gt;&lt;span style=&quot; font-weight:600; text-decoration: underline;&quot;&gt;Memo of the request&lt;/span&gt;&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
-     </property>
-    </widget>
-   </item>
-   <item row="1" column="0">
-    <widget class="QListView" name="requestContact">
-     <property name="minimumSize">
-      <size>
-       <width>256</width>
-       <height>231</height>
-      </size>
-     </property>
-     <property name="mouseTracking">
-      <bool>true</bool>
-     </property>
-     <property name="editTriggers">
-      <set>QAbstractItemView::EditKeyPressed|QAbstractItemView::SelectedClicked</set>
-     </property>
-     <property name="alternatingRowColors">
-      <bool>false</bool>
-     </property>
-     <property name="selectionMode">
-      <enum>QAbstractItemView::SingleSelection</enum>
+      <string>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;&lt;span style=&quot; font-weight:600; text-decoration: underline;&quot;&gt;Memo of the request&lt;/span&gt;&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
      </property>
     </widget>
    </item>
@@ -60,7 +37,7 @@
     <widget class="QListView" name="requestMemo">
      <property name="minimumSize">
       <size>
-       <width>521</width>
+       <width>500</width>
        <height>231</height>
       </size>
      </property>
@@ -90,18 +67,24 @@
      </property>
     </widget>
    </item>
-   <item row="2" column="0">
-    <widget class="QLabel" name="label_2">
+   <item row="0" column="0">
+    <widget class="QLabel" name="label">
      <property name="text">
-      <string>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p align=&quot;center&quot;&gt;&lt;span style=&quot; font-weight:600; text-decoration: underline;&quot;&gt;Recently closed requests&lt;/span&gt;&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
+      <string>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;&lt;span style=&quot; font-weight:600; text-decoration: underline;&quot;&gt;Open requests&lt;/span&gt;&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
      </property>
     </widget>
    </item>
    <item row="3" column="0" rowspan="8">
     <widget class="QListView" name="requestContactOld">
+     <property name="sizePolicy">
+      <sizepolicy hsizetype="Expanding" vsizetype="Expanding">
+       <horstretch>0</horstretch>
+       <verstretch>0</verstretch>
+      </sizepolicy>
+     </property>
      <property name="minimumSize">
       <size>
-       <width>256</width>
+       <width>225</width>
        <height>190</height>
       </size>
      </property>
@@ -116,20 +99,6 @@
      </property>
      <property name="selectionMode">
       <enum>QAbstractItemView::SingleSelection</enum>
-     </property>
-    </widget>
-   </item>
-   <item row="3" column="1" colspan="3">
-    <widget class="QLabel" name="label_4">
-     <property name="text">
-      <string>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p align=&quot;center&quot;&gt;&lt;span style=&quot; font-weight:600; text-decoration: underline;&quot;&gt;Details of the request&lt;/span&gt;&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
-     </property>
-    </widget>
-   </item>
-   <item row="4" column="1" colspan="3">
-    <widget class="QLabel" name="label_8">
-     <property name="text">
-      <string>Request from :</string>
      </property>
     </widget>
    </item>
@@ -149,51 +118,121 @@
      </property>
     </widget>
    </item>
-   <item row="5" column="1" colspan="2">
-    <widget class="QLabel" name="label_7">
+   <item row="4" column="1" colspan="3">
+    <widget class="QLabel" name="label_8">
+     <property name="sizePolicy">
+      <sizepolicy hsizetype="Fixed" vsizetype="Preferred">
+       <horstretch>0</horstretch>
+       <verstretch>0</verstretch>
+      </sizepolicy>
+     </property>
      <property name="text">
-      <string>My Zaddr :</string>
-     </property>
-    </widget>
-   </item>
-   <item row="5" column="4" colspan="3">
-    <widget class="QLineEdit" name="requestMyAddr">
-     <property name="minimumSize">
-      <size>
-       <width>351</width>
-       <height>25</height>
-      </size>
-     </property>
-     <property name="maximumSize">
-      <size>
-       <width>351</width>
-       <height>25</height>
-      </size>
-     </property>
-    </widget>
-   </item>
-   <item row="6" column="1" colspan="3">
-    <widget class="QLabel" name="label_5">
-     <property name="text">
-      <string>Give a Nickname:</string>
+      <string>Request from:</string>
      </property>
     </widget>
    </item>
    <item row="6" column="4" colspan="2">
     <widget class="QLineEdit" name="requestLabel">
+     <property name="sizePolicy">
+      <sizepolicy hsizetype="Expanding" vsizetype="Fixed">
+       <horstretch>0</horstretch>
+       <verstretch>0</verstretch>
+      </sizepolicy>
+     </property>
+     <property name="minimumSize">
+      <size>
+       <width>0</width>
+       <height>25</height>
+      </size>
+     </property>
      <property name="maxLength">
       <number>25</number>
      </property>
     </widget>
    </item>
-   <item row="7" column="1" colspan="4">
-    <widget class="QLabel" name="label_6">
+   <item row="10" column="3">
+    <widget class="QLabel" name="zaddrnew">
      <property name="text">
-      <string>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p align=&quot;right&quot;&gt;Choose a avatar for your contact :&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
+      <string/>
      </property>
     </widget>
    </item>
-   <item row="8" column="1" rowspan="2" colspan="3">
+   <item row="10" column="6">
+    <widget class="QPushButton" name="pushButton">
+     <property name="text">
+      <string>Add New Contact</string>
+     </property>
+     <property name="autoDefault">
+      <bool>false</bool>
+     </property>
+    </widget>
+   </item>
+   <item row="10" column="2">
+    <widget class="QLabel" name="requestCID">
+     <property name="text">
+      <string/>
+     </property>
+    </widget>
+   </item>
+   <item row="7" column="1" colspan="3">
+    <widget class="QLabel" name="label_6">
+     <property name="sizePolicy">
+      <sizepolicy hsizetype="Fixed" vsizetype="Preferred">
+       <horstretch>0</horstretch>
+       <verstretch>0</verstretch>
+      </sizepolicy>
+     </property>
+     <property name="text">
+      <string>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Choose an avatar for your contact:&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
+     </property>
+    </widget>
+   </item>
+   <item row="5" column="1" colspan="2">
+    <widget class="QLabel" name="label_7">
+     <property name="sizePolicy">
+      <sizepolicy hsizetype="Fixed" vsizetype="Preferred">
+       <horstretch>0</horstretch>
+       <verstretch>0</verstretch>
+      </sizepolicy>
+     </property>
+     <property name="text">
+      <string>My Zaddr:</string>
+     </property>
+    </widget>
+   </item>
+   <item row="10" column="1">
+    <widget class="QLabel" name="zaddrold">
+     <property name="text">
+      <string notr="true"/>
+     </property>
+    </widget>
+   </item>
+   <item row="10" column="5">
+    <widget class="QPushButton" name="cancel">
+     <property name="sizePolicy">
+      <sizepolicy hsizetype="Fixed" vsizetype="Fixed">
+       <horstretch>0</horstretch>
+       <verstretch>0</verstretch>
+      </sizepolicy>
+     </property>
+     <property name="baseSize">
+      <size>
+       <width>100</width>
+       <height>0</height>
+      </size>
+     </property>
+     <property name="text">
+      <string>Cancel</string>
+     </property>
+     <property name="autoDefault">
+      <bool>false</bool>
+     </property>
+     <property name="flat">
+      <bool>false</bool>
+     </property>
+    </widget>
+   </item>
+   <item row="7" column="4">
     <widget class="QComboBox" name="comboBoxAvatar">
      <property name="minimumSize">
       <size>
@@ -339,53 +378,74 @@
      </item>
     </widget>
    </item>
-   <item row="8" column="5" rowspan="2">
-    <widget class="QPushButton" name="cancel">
-     <property name="baseSize">
+   <item row="1" column="0">
+    <widget class="QListView" name="requestContact">
+     <property name="minimumSize">
       <size>
-       <width>100</width>
-       <height>0</height>
+       <width>225</width>
+       <height>231</height>
       </size>
      </property>
-     <property name="text">
-      <string>Cancel</string>
+     <property name="mouseTracking">
+      <bool>true</bool>
      </property>
-     <property name="autoDefault">
+     <property name="editTriggers">
+      <set>QAbstractItemView::EditKeyPressed|QAbstractItemView::SelectedClicked</set>
+     </property>
+     <property name="alternatingRowColors">
       <bool>false</bool>
      </property>
-     <property name="flat">
-      <bool>false</bool>
+     <property name="selectionMode">
+      <enum>QAbstractItemView::SingleSelection</enum>
      </property>
     </widget>
    </item>
-   <item row="8" column="6" rowspan="2">
-    <widget class="QPushButton" name="pushButton">
+   <item row="2" column="0">
+    <widget class="QLabel" name="label_2">
      <property name="text">
-      <string>Add this new Contact</string>
-     </property>
-     <property name="autoDefault">
-      <bool>false</bool>
+      <string>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;&lt;span style=&quot; font-weight:600; text-decoration: underline;&quot;&gt;Recently closed requests&lt;/span&gt;&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
      </property>
     </widget>
    </item>
-   <item row="10" column="1">
-    <widget class="QLabel" name="zaddrold">
+   <item row="3" column="1" colspan="3">
+    <widget class="QLabel" name="label_4">
+     <property name="sizePolicy">
+      <sizepolicy hsizetype="Fixed" vsizetype="Preferred">
+       <horstretch>0</horstretch>
+       <verstretch>0</verstretch>
+      </sizepolicy>
+     </property>
      <property name="text">
-      <string notr="true"/>
+      <string>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;&lt;span style=&quot; font-weight:600; text-decoration: underline;&quot;&gt;Details of the request&lt;/span&gt;&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
      </property>
     </widget>
    </item>
-   <item row="10" column="3">
-    <widget class="QLabel" name="zaddrnew">
+   <item row="6" column="1" colspan="3">
+    <widget class="QLabel" name="label_5">
+     <property name="sizePolicy">
+      <sizepolicy hsizetype="Fixed" vsizetype="Preferred">
+       <horstretch>0</horstretch>
+       <verstretch>0</verstretch>
+      </sizepolicy>
+     </property>
      <property name="text">
-      <string/>
+      <string>Give a Nickname:</string>
      </property>
     </widget>
    </item>
-   <item row="10" column="2">
-    <widget class="QLabel" name="requestCID">
-     <property name="text">
-      <string/>
+   <item row="5" column="4" colspan="3">
+    <widget class="QLineEdit" name="requestMyAddr">
+     <property name="minimumSize">
+      <size>
+       <width>351</width>
+       <height>25</height>
+      </size>
+     </property>
+     <property name="maximumSize">
+      <size>
+       <width>351</width>
+       <height>25</height>
+      </size>
      </property>
     </widget>
    </item>


### PR DESCRIPTION
- Titles aligned to the left
- SDLogo dropdown aligned to right of "choose an avatar". 
- Updated grammar and simplified buttons.
- Fixed display bug on minimum width.
- Fixed input box bug for Give a Nickname

The input box bug was because min height wasn't set to 25 like other two boxes. Normally, we can do all these edits in CSS, but this is legit also.

![Screenshot from 2020-06-08 00-24-16](https://user-images.githubusercontent.com/18726788/83993028-34e9b300-a920-11ea-9478-290c829df8f4.png)
